### PR TITLE
only trigger when appName is "zoom.us"

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -64,7 +64,7 @@ local endMeetingDebouncer = hs.timer.delayed.new(0.2, function()
 end)
 
 appWatcher = hs.application.watcher.new(function (appName, eventType, appObject)
-  if (eventType == hs.application.watcher.launched) then
+  if (appName == "zoom.us" and eventType == hs.application.watcher.launched) then
     zoomState:start()
 
     watcher = appObject:newWatcher(function (element, event, watcher, userData)


### PR DESCRIPTION
Currently `zoomState:start()` for all applications.
This patch ensures that only "zoom.us" triggers any behaviour