### PR TITLE
Spoon thinking meeting is ended while still running.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -64,7 +64,7 @@ zoomState = machine.create({
 
 local endMeetingDebouncer = hs.timer.delayed.new(0.2, function()
   -- Only end the meeting if the "Meeting" menu is no longer present
-  if not _check({"Meeting", "Invite"}) then
+  if not _check({"Meeting", "Invite..."}) then
     zoomState:endMeeting()
   end
 end)


### PR DESCRIPTION
The menu item in the Meeting menu has changed from "Invite" to "Invite..." and is causing the spoon to think the meeting has ended on its first pool.