### PR TITLE
Detect Zoom state on startup even if Zoom UI is already running

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -156,6 +156,13 @@ function obj:stop()
   stopTimer()
 end
 
+function obj:kill()
+  app = hs.application.find("zoom.us")
+  if (app ~= nil) then
+    app:kill()
+  end
+end
+
 function _check(tbl)
   local check = hs.application.get("zoom.us")
   if (check ~= nil) then


### PR DESCRIPTION
The previous code would only discover the Zoom UI when the "launched" event is registered, but if Zoom is already running when the spoon starts up, this event would never fire 

Now when calling start() we check if Zoom is already running, and if yes, we set up the proper watch on the UI elements

End result: it is no longer necessary to shut down Zoom and restart it if the Spoon code is reloaded